### PR TITLE
Allow empty string in BCFComponent Color setter

### DIFF
--- a/Xbim.BCF/XMLNodes/BCFComponent.cs
+++ b/Xbim.BCF/XMLNodes/BCFComponent.cs
@@ -19,13 +19,17 @@ namespace Xbim.BCF.XMLNodes
             get { return _color; }
             set
             {
-                if (!String.IsNullOrEmpty(value) && IsHex(value))
+                if (!String.IsNullOrEmpty(value))
                 {
+                    if (!IsHex(value))
+                    {
+                        throw new ArgumentException(this.GetType().Name + " - Color - must be a valid hex sequence");
+                    }
                     _color = value;
                 }
                 else
                 {
-                    throw new ArgumentException(this.GetType().Name + " - Color - must be a valid hex sequence");
+                    _color = "FFFFFF00";
                 }
             }
         }


### PR DESCRIPTION
BCFComponent color setter should allow empty string to set a default value, rather than raise exception. Some applications might write empty string or no color information when serializing. This change allows the file to deserialize successfully in this situation, even if the source xml doesn't quite conform to the expected specification. 
